### PR TITLE
feat: 포맷터를 지원하는 컨버전 서비스 구현 및 테스트 추가

### DIFF
--- a/src/test/java/hello/typeconverter/fomatter/FormattingConversionServiceTest.java
+++ b/src/test/java/hello/typeconverter/fomatter/FormattingConversionServiceTest.java
@@ -1,0 +1,29 @@
+package hello.typeconverter.fomatter;
+
+import hello.typeconverter.converter.IpPortToStringConverter;
+import hello.typeconverter.converter.StringToIpPortConverter;
+import hello.typeconverter.type.IpPort;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.format.support.DefaultFormattingConversionService;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class FormattingConversionServiceTest {
+
+    @Test
+    void formattingConversionService() {
+        DefaultFormattingConversionService conversionService = new DefaultFormattingConversionService();
+
+        conversionService.addConverter(new StringToIpPortConverter());
+        conversionService.addConverter(new IpPortToStringConverter());
+
+        conversionService.addFormatter(new MyNumberFormatter());
+
+        IpPort ipPort = conversionService.convert("127.0.0.1:8080", IpPort.class);
+        assertThat(ipPort).isEqualTo(new IpPort("127.0.0.1", 8080));
+
+        assertThat(conversionService.convert(1000, String.class)).isEqualTo("1,000");
+        assertThat(conversionService.convert("1,000", Long.class)).isEqualTo(1000L);
+    }
+}


### PR DESCRIPTION
### 구현 내용
- `DefaultFormattingConversionService`를 사용하여 포맷터를 지원하는 컨버전 서비스 구현  
- `StringToIpPortConverter`, `IpPortToStringConverter` 등록  
- `MyNumberFormatter`를 포맷터로 등록해 숫자 ↔ 문자열 변환 기능 추가  
- 컨버터와 포맷터 모두 `convert()` 메서드를 통해 동일하게 동작함을 검증  

### 테스트 결과
- `"127.0.0.1:8080"` → `IpPort("127.0.0.1", 8080)` 변환 성공  
- `1000` → `"1,000"` 포맷 변환 및 역변환(`"1,000"` → `1000L`) 성공  
- 로그 출력 및 Locale 기반 포맷 적용 정상 동작 확인
