### PR TITLE
feat: WebMvcConfigurer를 통한 포맷터 적용 및 컨버터 우선순위 조정

### DIFF
--- a/src/main/java/hello/typeconverter/WebConfig.java
+++ b/src/main/java/hello/typeconverter/WebConfig.java
@@ -1,9 +1,8 @@
 package hello.typeconverter;
 
-import hello.typeconverter.converter.IntegerToStringConverter;
 import hello.typeconverter.converter.IpPortToStringConverter;
-import hello.typeconverter.converter.StringToIntegerConverter;
 import hello.typeconverter.converter.StringToIpPortConverter;
+import hello.typeconverter.fomatter.MyNumberFormatter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -13,9 +12,13 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
-        registry.addConverter(new StringToIntegerConverter());
-        registry.addConverter(new IntegerToStringConverter());
+        //주석처리 우선순위
+        //registry.addConverter(new StringToIntegerConverter());
+        //registry.addConverter(new IntegerToStringConverter());
         registry.addConverter(new StringToIpPortConverter());
         registry.addConverter(new IpPortToStringConverter());
+
+        //추가
+        registry.addFormatter(new MyNumberFormatter());
     }
 }


### PR DESCRIPTION
### 구현 내용
- `WebMvcConfigurer`의 `addFormatters()`를 오버라이드하여 포맷터 등록  
- `StringToIpPortConverter`, `IpPortToStringConverter`를 컨버터로 추가  
- `MyNumberFormatter`를 등록해 숫자 ↔ 문자열 변환 기능 적용  
- 숫자 컨버터와 포맷터의 충돌 방지를 위해 기존 컨버터 주석 처리  

### 동작 확인
- `/converter-view` 요청 시 `${{number}}`가 `10,000`으로 출력됨  
- `/hello-v2?data=10,000` 요청 시 문자열 `"10,000"`이 Integer 타입 `10000`으로 정상 변환  
- `MyNumberFormatter` 로그 출력 및 Locale 기반 포맷 적용 정상 작동 확인  