### PR TITLE
feat: 스프링 기본 포맷터(@NumberFormat, @DateTimeFormat) 적용 예제 추가

### DIFF
--- a/src/main/java/hello/typeconverter/controller/FormatterController.java
+++ b/src/main/java/hello/typeconverter/controller/FormatterController.java
@@ -1,0 +1,39 @@
+package hello.typeconverter.controller;
+
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.NumberFormat;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.time.LocalDateTime;
+
+@Controller
+public class FormatterController {
+
+    @GetMapping("/formatter/edit")
+    public String formatterForm(Model model) {
+        Form form = new Form();
+        form.setNumber(10000);
+        form.setLocalDateTime(LocalDateTime.now());
+        model.addAttribute("form", form);
+        return "formatter-form";
+    }
+
+    @PostMapping("/formatter/edit")
+    public String formatterEdit(@ModelAttribute Form form) {
+        return "formatter-view";
+    }
+
+    @Data
+    static class Form{
+        @NumberFormat(pattern = "###,###")
+        private Integer number;
+
+        @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime localDateTime;
+    }
+}

--- a/src/main/resources/templates/formatter-form.html
+++ b/src/main/resources/templates/formatter-form.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<form th:object="${form}" th:method="post">
+    number <input type="text" th:field="*{number}"><br/>
+    localDateTime <input type="text" th:field="*{localDateTime}"><br/>
+    <input type="submit"/>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/formatter-view.html
+++ b/src/main/resources/templates/formatter-view.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<ul>
+    <li>${form.number}: <span th:text="${form.number}" ></span></li>
+    <li>${{form.number}}: <span th:text="${{form.number}}" ></span></li>
+    <li>${form.localDateTime}: <span th:text="${form.localDateTime}" ></span></li>
+    <li>${{form.localDateTime}}: <span th:text="${{form.localDateTime}}" ></span></li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
### 구현 내용
- `@NumberFormat`과 `@DateTimeFormat`을 이용해 필드별 포맷 지정 기능 구현  
- `FormatterController`를 통해 `number`, `localDateTime` 필드에 포맷 적용  
- 입력 폼(`formatter-form.html`)과 결과 화면(`formatter-view.html`) 구성  
- `${{...}}` 표현식 사용으로 스프링 `ConversionService` 자동 포맷팅 확인  

### 동작 확인
- `/formatter/edit` 요청 시 폼에 숫자 및 날짜 입력 가능  
- 전송 후 포맷이 적용된 결과(`10,000`, `2021-01-01 00:00:00`) 출력  
- 로그 및 화면 렌더링을 통해 포맷터 정상 적용 확인  